### PR TITLE
Fix setColumnWidth type error and ELF file handling issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 IDA plugin to export symbols from IDA database to ELF file or plaintext.
 
-Added support for IDA 7.4+ (Python 3.8), original repo only works for 7.0-7.3. Tested on IDA Pro 7.7 and IDA Pro 8.3.
+Added support for IDA 7.4+ (Python 3.8), original repo only works for 7.0-7.3. Tested on IDA Pro 7.7, IDA Pro 8.3 and IDA Pro 9.1.
 
 Idea taken from https://github.com/danigargu/syms2elf but written from scratch.
 
@@ -35,6 +35,7 @@ backup original file and use at your own risk.
 - Updated idapython api
 - Redesigned dialog using layouts for better flexibility instead of hard-coded setGeometry.
 - More convenient selection buttons
+- Fix some bugs.
 
 ## Screenshot
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 IDA plugin to export symbols from IDA database to ELF file or plaintext.
 
-Added support for IDA 7.4+ (Python 3.8), original repo only works for 7.0-7.3. Tested on IDA Pro 7.7, IDA Pro 8.3 and IDA Pro 9.1.
+Original repository added support for IDA 7.4+ (Python 3.8) and tested on IDA Pro 7.7, IDA Pro 8.3. But IDAPython 9.0 has modified some API functions, so older plugins are not compatible with the new version. This fork has been adapted to IDA Pro 9.1 and has fixed some bugs. It has been tested and works properly on Version 9.1.250226 Windows x64 (64-bit address size).
 
 Idea taken from https://github.com/danigargu/syms2elf but written from scratch.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Copy all files from plugin durectory to IDA plugin directory.
     USER_SEGMENTS = ['.text', '.data', '.bss', '.rodata']
     ```
 
-- Change export symbols types and options as you want. 
+- Change export symbols types and options as you want. Note that if you choose to export an ELF file, you must specify a file extension that is not .txt.
 
 - In file dialog, You can save file as plaintext or a copy of input ELF file with IDA symbols imported by selecting file type.
 

--- a/plugin/exportsymbols.py
+++ b/plugin/exportsymbols.py
@@ -621,8 +621,12 @@ class ELF:
 def write_symbols(input_file, output_file, symbols):
     try:
         logger("reading ELF file")
-        with open(input_file, 'rb') as f:
-            bin = ELF(f.read())
+        try:
+            with open(input_file, 'rb') as f:
+                bin = ELF(f.read())
+        except:
+            logger("Error while open ELF file")
+            return
 
         if len(symbols) < 1:
             logger("No symbols to export")
@@ -731,14 +735,15 @@ def write_symbols(input_file, output_file, symbols):
         bin.save(output_file)
 
     except:
-        logger('Write ELF Error')
+        logger(traceback.format_exc())
 
 
 def export2elf(filename, symbols):
     show_proc_info()
-    input_file_name = ida_nalt.get_root_filename()
+    input_file_name = idaapi.get_input_file_path()
+    logger(f'Process original file: {input_file_name}')
     input_file_type = idaapi.get_file_type_name()
-    print("Input file type: {}".format(input_file_type))
+    logger("Input file type: {}".format(input_file_type))
     if  "ELF" not in input_file_type:
         logger("Only ELF input file supported!")
         return
@@ -885,9 +890,9 @@ class Ui_ExportSymbols_Dialog(object):
         self.checkExports.setText(_translate("Dialog", "Exports"))
         self.segmentsWidget.setSortingEnabled(False)
         self.segmentsWidget.setHorizontalHeaderLabels( ["Name","Start","End"])
-        self.segmentsWidget.setColumnWidth(0, self.segmentsWidget.width() / 2  )
-        self.segmentsWidget.setColumnWidth(1, self.segmentsWidget.width() / 4  )
-        self.segmentsWidget.setColumnWidth(2, self.segmentsWidget.width() / 4  )
+        self.segmentsWidget.setColumnWidth(0, int(self.segmentsWidget.width() / 2) )
+        self.segmentsWidget.setColumnWidth(1, int(self.segmentsWidget.width() / 4)  )
+        self.segmentsWidget.setColumnWidth(2, int(self.segmentsWidget.width() / 4)  )
         self.selectAllSegments.setText(_translate("Dialog", "Select all"))
         self.unselectAllSegments.setText(_translate("Dialog", "Unselect all"))
         self.selectUserSegments.setText(_translate("Dialog", "Select custom"))


### PR DESCRIPTION
## Description
Fixed bugs encountered when exporting symbol table to ELF:
1. Corrected the type error in `setColumnWidth` that caused missing GUI button text.
2. Fixed the ELF file opening error caused by passing a filename instead of a file path to `write_symbols`.

The original information in the IDA output window is shown in the figure below: 

![image](https://github.com/user-attachments/assets/1407bf02-cf07-4911-a188-57047a4d985d)

## Changes
- Ensured `setColumnWidth` receives the correct argument type.
- Ensured `write_symbols` accept a full file path.

## Testing
Verified the plugin works correctly in IDA Pro 9.1.250226 (Windows x64, 64-bit address size).

